### PR TITLE
feat(backend): add scraper service and routes for trend scraping fuctionality

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -9,7 +9,8 @@ from fastapi.middleware.cors import CORSMiddleware
 from .core.config import settings
 from .core.service_manager import service_manager
 from .services.discord_service import DiscordService
-from .routes import discord_routes, system_routes
+from .services.scraper_service import ScraperService
+from .routes import discord_routes, system_routes, scraper_routes
 
 # Configure logging
 logging.basicConfig(
@@ -27,6 +28,7 @@ async def lifespan(app: FastAPI):
 
     # Register services
     service_manager.register_service(DiscordService())
+    service_manager.register_service(ScraperService())
 
     # Initialize all services
     init_results = await service_manager.initialize_all()
@@ -66,6 +68,7 @@ app.add_middleware(
 # Register routes
 app.include_router(system_routes.router)
 app.include_router(discord_routes.router)
+app.include_router(scraper_routes.router)
 
 
 @app.get("/")
@@ -75,7 +78,13 @@ async def root():
         "app": settings.app_name,
         "version": settings.app_version,
         "status": "running",
-        "services": service_manager.list_services()
+        "services": service_manager.list_services(),
+        "endpoints": {
+            "docs": "/docs",
+            "health": "/health",
+            "discord": "/discord",
+            "scraper": "/scraper"
+        }
     }
 
 

--- a/backend/app/routes/__init__.py
+++ b/backend/app/routes/__init__.py
@@ -1,1 +1,5 @@
 """API routes for the backend."""
+
+from . import discord_routes, system_routes, scraper_routes
+
+__all__ = ["discord_routes", "system_routes", "scraper_routes"]

--- a/backend/app/routes/scraper_routes.py
+++ b/backend/app/routes/scraper_routes.py
@@ -1,0 +1,142 @@
+"""Scraper service API routes."""
+
+from fastapi import APIRouter, HTTPException, Query
+from typing import Optional, Dict, Any
+
+from ..core.service_manager import service_manager
+from ..services.discord_service import DiscordMessage, DiscordEmbed
+
+router = APIRouter(prefix="/scraper", tags=["Scraper"])
+
+
+@router.get("/scrapers")
+async def list_scrapers():
+    """List all available scrapers."""
+    scraper_service = service_manager.get_service("scraper")
+    if not scraper_service:
+        raise HTTPException(
+            status_code=503, detail="Scraper service not available")
+
+    scrapers = scraper_service.list_scrapers()
+    return {"scrapers": scrapers, "total": len(scrapers)}
+
+
+@router.post("/scrape")
+async def scrape_trends(
+    scraper_name: str = Query(default="techcrunch",
+                              description="Scraper to use"),
+    url: Optional[str] = Query(
+        default=None, description="URL to scrape (optional)"),
+    send_to_discord: bool = Query(
+        default=False, description="Send results to Discord")
+):
+    """Scrape trends and optionally send to Discord."""
+    scraper_service = service_manager.get_service("scraper")
+    if not scraper_service:
+        raise HTTPException(
+            status_code=503, detail="Scraper service not available")
+
+    # Scrape trends
+    result = await scraper_service.scrape_trends(scraper_name, url)
+
+    if not result.success:
+        raise HTTPException(
+            status_code=400, detail=result.error or result.message)
+
+    # Send to Discord if requested
+    if send_to_discord and result.data:
+        discord_service = service_manager.get_service("discord")
+        if discord_service:
+            trends_data = result.data.get('trends', [])
+
+            # Create proper DiscordMessage object
+            summary_message = f"🔍 **Scraping Results**\n"
+            summary_message += f"Source: {result.data.get('source', 'Unknown')}\n"
+            summary_message += f"Total trends found: {result.data.get('total_count', 0)}\n"
+            summary_message += f"Scraped at: {result.data.get('scraped_at', 'Unknown')}"
+
+            discord_message = DiscordMessage(
+                content=summary_message,
+                username="Quillix Scraper"
+            )
+            await discord_service.send_message(discord_message)
+
+            # Send top 3 trends as embeds
+            for i, trend in enumerate(trends_data[:3], 1):
+                await discord_service.send_trend_notification(trend)
+
+    return {
+        "status": "success",
+        "message": result.message,
+        "data": result.data,
+        "sent_to_discord": send_to_discord
+    }
+
+
+@router.post("/scrape-and-notify")
+async def scrape_and_notify_all(
+    scraper_name: str = Query(default="techcrunch",
+                              description="Scraper to use"),
+    url: Optional[str] = Query(default=None, description="URL to scrape"),
+    max_trends: int = Query(
+        default=5, description="Max trends to send to Discord")
+):
+    """Scrape trends and send all to Discord with formatting."""
+    scraper_service = service_manager.get_service("scraper")
+    discord_service = service_manager.get_service("discord")
+
+    if not scraper_service:
+        raise HTTPException(
+            status_code=503, detail="Scraper service not available")
+    if not discord_service:
+        raise HTTPException(
+            status_code=503, detail="Discord service not available")
+
+    # Scrape trends
+    result = await scraper_service.scrape_trends(scraper_name, url)
+
+    if not result.success:
+        raise HTTPException(
+            status_code=400, detail=result.error or result.message)
+
+    trends_data = result.data.get('trends', [])
+
+    # Create proper DiscordEmbed object
+    summary_embed = DiscordEmbed(
+        title="🔍 New Scraping Results",
+        description=f"Found **{len(trends_data)}** trending topics from **{result.data.get('source', 'Unknown')}**",
+        color=0x00ff00,
+        fields=[
+            {
+                "name": "Source",
+                "value": result.data.get('source', 'Unknown'),
+                "inline": True
+            },
+            {
+                "name": "Total Trends",
+                "value": str(len(trends_data)),
+                "inline": True
+            },
+            {
+                "name": "Scraped At",
+                "value": result.data.get('scraped_at', 'Unknown')[:19].replace('T', ' '),
+                "inline": True
+            }
+        ]
+    )
+
+    await discord_service.send_embed(summary_embed)
+
+    # Send individual trends
+    sent_count = 0
+    for trend in trends_data[:max_trends]:
+        discord_result = await discord_service.send_trend_notification(trend)
+        if discord_result.success:
+            sent_count += 1
+
+    return {
+        "status": "success",
+        "message": f"Scraped {len(trends_data)} trends, sent {sent_count} to Discord",
+        "scraped_count": len(trends_data),
+        "sent_to_discord": sent_count
+    }

--- a/backend/app/services/scraper_service.py
+++ b/backend/app/services/scraper_service.py
@@ -1,0 +1,96 @@
+"""Scraper service integration with quillix-scraper package"""
+
+from ..core.service import BaseService, ServiceResponse
+import sys
+import os
+from typing import Optional, Dict, Any, List
+from pathlib import Path
+
+# Add the scraper directory to the path so we can import quillix_scraper
+# scraper_path = Path(__file__).parent.parent.parent / "scraper"
+# sys.path.insert(0, str(scraper_path))
+
+try:
+    from quillix_scraper import ScraperManager as QuillixScraperManager
+    from quillix_scraper import TechCrunchScraper
+    SCRAPER_AVAILABLE = True
+except ImportError as e:
+    print(f"Warning: Could not import quillix_scraper: {e}")
+    SCRAPER_AVAILABLE = False
+
+
+class ScraperService(BaseService):
+    """Service for scraping trends using quillix-scraper"""
+
+    def __init__(self):
+        super().__init__("scraper")
+        self.scraper_manager: Optional[QuillixScraperManager] = None
+        self.available = SCRAPER_AVAILABLE
+
+    async def initialize(self) -> bool:
+        """Initialize the scraper service"""
+        if not self.available:
+            self.logger.error("quillix-scraper package not available")
+            return False
+
+        try:
+            self.scraper_manager = QuillixScraperManager()
+            # Register available scrapers
+            self.scraper_manager.register_scraper(
+                'techcrunch', TechCrunchScraper())
+
+            self.logger.info("Scraper service initialized successfully")
+            return True
+        except Exception as e:
+            self.logger.error(f"Failed to initialize scraper service: {e}")
+            return False
+
+    async def health_check(self) -> ServiceResponse:
+        """Check scraper scraper service health"""
+        if not self.available or not self.scraper_manager:
+            return ServiceResponse(
+                success=False,
+                message="Scraper service not available"
+            )
+
+        return ServiceResponse(
+            success=True,
+            message="Scraper service is healthy",
+            data={
+                "available_scrapers": self.scraper_manager.list_scrapers()
+            }
+        )
+
+    async def cleanup(self) -> None:
+        """Cleanup scraper service resources"""
+        pass
+
+    async def scrape_trends(self, scraper_name: str = "techcrunch", url: Optional[str] = None) -> ServiceResponse:
+        """Scrape trends using the specifide scraper"""
+        if not self.scraper_manager:
+            return ServiceResponse(
+                success=False,
+                message="Scraper service not initialized"
+            )
+
+        try:
+            trends = self.scraper_manager.scrape(scraper_name, url)
+
+            return ServiceResponse(
+                success=True,
+                message=f"Successfully scraped {trends.total_count} trends",
+                data=trends.to_dict()
+            )
+        except Exception as e:
+            self.logger.error(f"Error scraping trends {e}")
+            return ServiceResponse(
+                success=False,
+                message="Failed to scrape trends",
+                error=str(e)
+            )
+
+    def list_scrapers(self) -> List[str]:
+        """List available scrapers"""
+        if not self.scraper_manager:
+            return []
+        return self.scraper_manager.list_scrapers()

--- a/backend/app/services/scraper_service.py
+++ b/backend/app/services/scraper_service.py
@@ -66,7 +66,7 @@ class ScraperService(BaseService):
         pass
 
     async def scrape_trends(self, scraper_name: str = "techcrunch", url: Optional[str] = None) -> ServiceResponse:
-        """Scrape trends using the specifide scraper"""
+        """Scrape trends using the specified scraper"""
         if not self.scraper_manager:
             return ServiceResponse(
                 success=False,

--- a/backend/quick_test.sh
+++ b/backend/quick_test.sh
@@ -21,7 +21,7 @@ curl -s "$BASE_URL/scraper/scrapers" | jq '.'
 echo -e "\n5. Testing scrape (without Discord)..."
 curl -s -X POST "$BASE_URL/scraper/scrape?scraper_name=techcrunch&send_to_discord=false" | jq '.data.total_count'
 
-echo -e "\n5. Testing scrape (with Discord)..."
+echo -e "\n6. Testing scrape (with Discord)..."
 curl -s -X POST "$BASE_URL/scraper/scrape?scraper_name=techcrunch&send_to_discord=true" | jq '.data.total_count'
 
 echo -e "\n✅ Quick tests completed!"

--- a/backend/quick_test.sh
+++ b/backend/quick_test.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+echo "🧪 Testing Quillix Backend API"
+echo "==============================="
+
+BASE_URL="http://localhost:8000"
+
+echo "1. Testing root endpoint..."
+curl -s "$BASE_URL/" | jq '.'
+
+echo -e "\n2. Testing health check..."
+curl -s "$BASE_URL/system/health" | jq '.'
+
+echo -e "\n3. Testing Discord message..."
+curl -s -X POST "$BASE_URL/discord/send-message" \
+  -H "Content-Type: application/json" \
+  -d '{"content": "🧪 Test from curl!", "username": "Curl Tester"}' | jq '.'
+
+echo -e "\n4. Testing scraper list..."
+curl -s "$BASE_URL/scraper/scrapers" | jq '.'
+
+echo -e "\n5. Testing scrape (without Discord)..."
+curl -s -X POST "$BASE_URL/scraper/scrape?scraper_name=techcrunch&send_to_discord=false" | jq '.data.total_count'
+
+echo -e "\n5. Testing scrape (with Discord)..."
+curl -s -X POST "$BASE_URL/scraper/scrape?scraper_name=techcrunch&send_to_discord=true" | jq '.data.total_count'
+
+echo -e "\n✅ Quick tests completed!"


### PR DESCRIPTION
This pull request introduces a new `ScraperService` to the backend, along with API routes for interacting with the service. The `ScraperService` integrates with the `quillix-scraper` package to scrape trends and optionally send results to Discord. Additionally, a quick testing script has been added to validate key endpoints.

### Integration of `ScraperService`:

* **Service registration and initialization**:
  - Added `ScraperService` to the service manager in `backend/app/main.py` for initialization and health checks.
  - Implemented `ScraperService` in `backend/app/services/scraper_service.py` to manage scrapers and handle scraping operations using the `quillix-scraper` package.

* **API routes for scraping**:
  - Created `scraper_routes.py` with endpoints to list scrapers, scrape trends, and send results to Discord. Includes functionality for sending detailed notifications using Discord embeds.
  - Registered `scraper_routes` in `backend/app/main.py` and exposed scraper-related endpoints in the root response. [[1]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3R71) [[2]](diffhunk://#diff-82608d38c4441937a3cfb9ff7da1bed9dd59292dec62308de75bfaa2809419a3L78-R87)

### Enhancements to backend testing:

* **Quick testing script**:
  - Added `quick_test.sh` to automate testing of key backend endpoints, including the new scraper routes.

### Code organization improvements:

* **Route imports**:
  - Updated `backend/app/routes/__init__.py` to include `scraper_routes` for better modularity.